### PR TITLE
set bufc to (long) unsigned

### DIFF
--- a/b64.h
+++ b/b64.h
@@ -10,7 +10,7 @@
 
 typedef struct b64_buffer {
     char * ptr;
-    int bufc;
+    size_t bufc;
 } b64_buffer_t;
 
 /**


### PR DESCRIPTION
currently 

```sh
../b64/buffer.c:25:18: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
   25 |         if (size > buf->bufc * B64_BUFFER_SIZE)
      |                  ^
../b64/buffer.c:27:29: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
   27 |                 while (size > buf->bufc * B64_BUFFER_SIZE) buf->bufc++;
```

this PR sets `bufc` to unsigned