### PR TITLE
Add support for building static library with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME b64c)
 project(${PROJECT_NAME} LANGUAGES C)
 
-add_library(${PROJECT_NAME} SHARED 
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
+add_library(${PROJECT_NAME}
     buffer.c
     decode.c
     encode.c


### PR DESCRIPTION
Hi, thanks for this library!

This PR adds support for building `libb64c` as a static library.

```sh
cmake -S . -B build -DBUILD_SHARED_LIBS=OFF
cmake --build build
# ... [100%] Linking C static library libb64c.a ...
```

It defaults to a shared library for backwards compatibility.

More info on `BUILD_SHARED_LIBS`: https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html